### PR TITLE
Corrigindo compatibilidade com PHP 7.4.*

### DIFF
--- a/src/PhpQuery.php
+++ b/src/PhpQuery.php
@@ -117,7 +117,7 @@ abstract class PhpQuery {
   public static $enableCssShorthand = FALSE;
 
   public static function use_function($ns = '\\', $func = 'pq') {
-    if ($ns{0} !== '\\') {
+    if ($ns[0] !== '\\') {
       $ns = '\\' . $ns;
     }
     if (!function_exists($ns . '\\' . $func)) {

--- a/src/PhpQueryObject.php
+++ b/src/PhpQueryObject.php
@@ -1094,7 +1094,7 @@ class PhpQueryObject implements \Iterator, \Countable, \ArrayAccess {
         if (!$param)
           break;
         // nth-child(n+b) to nth-child(1n+b)
-        if ($param{0} == 'n')
+        if ($param[0] == 'n')
           $param = '1' . $param;
         // :nth-child(index/even/odd/equation)
         if ($param == 'even' || $param == 'odd')


### PR DESCRIPTION
Corrigindo erro de compatibilidade com PHP 7.4.* informado no repositório correios-consulta, no link https://github.com/cagartner/correios-consulta/issues/42 pelo @paulosfjunior